### PR TITLE
Symetric encryption for peer-to-peer communication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,6 +310,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +344,17 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link 0.2.0",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -594,6 +639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -693,6 +739,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -768,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -1065,6 +1112,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1187,6 +1252,15 @@ dependencies = [
  "hashbrown 0.16.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1501,6 +1575,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1614,15 +1694,19 @@ dependencies = [
 name = "pillar_crypto"
 version = "0.1.0"
 dependencies = [
+ "chacha20poly1305",
  "crypto",
  "ed25519",
  "ed25519-dalek",
+ "flume",
+ "hkdf",
  "lz4_flex",
  "pillar_serialize",
  "rand",
  "rand_core 0.6.4",
  "sha3",
  "slotmap",
+ "x25519-dalek",
 ]
 
 [[package]]
@@ -1669,6 +1753,17 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "postcard"
@@ -2552,6 +2647,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3343,6 +3448,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3367,6 +3484,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zstd"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Pillar is a zero-trust decentralized ledger that implements a Proof of Reputatio
 
 - [`pillar/`](pillar/) – Entrypoint for managing a Pillar node.
 - [`libs/pillar_core/`](libs/pillar_core/) – Core protocol logic and data structures.
-- [`libs/pillar_crypto/`](libs/pillar_crypto/) – Cryptographic primitives, including hashing, signing, and Merkle structures.
+- [`libs/pillar_crypto/`](libs/pillar_crypto/) – Cryptographic primitives, including hashing, signing, encryption, and Merkle structures.
 - [`libs/pillar_serialize/`](libs/pillar_serialize/) – Lightweight serialization utilities.
 - [`pillar_monitor/`](pillar_monitor/) – A web-based frontend for monitoring a node.
 - [`vm_mesh/`](vm_mesh/) – A framework for distributed testing and simulation using QEMU.

--- a/libs/pillar_core/src/nodes/node.rs
+++ b/libs/pillar_core/src/nodes/node.rs
@@ -461,6 +461,9 @@ impl Node {
             Message::DiscoveryRequest => {
                 Ok(Message::DiscoveryResponse(self.clone().into()))
             },
+            Message::Ping => {
+                Ok(Message::Ping)
+            },
             _ => Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
                 "Expected a request",

--- a/libs/pillar_core/src/primitives/messages.rs
+++ b/libs/pillar_core/src/primitives/messages.rs
@@ -61,6 +61,12 @@ pub enum Message {
     PercentileFilteredPeerRequest(f32, f32),
     // response with peers filtered between a lower percentile and an upper percentile based on reputation
     PercentileFilteredPeerResponse(Vec<Peer>),
+    // encrypted message
+    EncryptedMessage(Vec<u8>),
+    // privacy request -- holds public key
+    PrivacyRequest(StdByteArray),
+    // privacy response, holds public key
+    PrivacyResponse(StdByteArray),
     // error message
     Error(String)
 }
@@ -93,6 +99,9 @@ impl Message{
             Message::ChainSyncResponse(_) => "ChainSyncResponse".to_string(),
             Message::PercentileFilteredPeerRequest(_, _) => "PercentileFilteredPeerRequest".to_string(),
             Message::PercentileFilteredPeerResponse(_) => "PercentileFilteredPeerResponse".to_string(),
+            Message::EncryptedMessage(_) => "EncryptedMessage".to_string(),
+            Message::PrivacyRequest(_) => "PrivacyRequest".to_string(),
+            Message::PrivacyResponse(_) => "PrivacyResponse".to_string(),
             Message::Error(_) => "Error".to_string(),
         }
     }
@@ -125,6 +134,17 @@ impl Message{
             Message::Error(_) => 23,
             Message::DiscoveryRequest => 24,
             Message::DiscoveryResponse(_) => 25,
+            Message::EncryptedMessage(_) => 26,
+            Message::PrivacyRequest(_) => 27,
+            Message::PrivacyResponse(_) => 28,
+        }
+    }
+
+    /// Indicates whether a node should support encryption for this message type
+    pub fn encryption_supported(&self) -> bool {
+        match self{
+            Message::Ping => true,
+            _ => false
         }
     }
 }

--- a/libs/pillar_core/src/protocol/serialization.rs
+++ b/libs/pillar_core/src/protocol/serialization.rs
@@ -92,6 +92,9 @@ impl PillarSerialize for crate::primitives::messages::Message {
             },
             Self::PercentileFilteredPeerResponse(c) => c.serialize_pillar(),
             Self::DiscoveryResponse(c) => c.serialize_pillar(),
+            Self::EncryptedMessage(c) => c.serialize_pillar(),
+            Self::PrivacyRequest(c) => c.serialize_pillar(),
+            Self::PrivacyResponse(c) => c.serialize_pillar(),
             Self::Error(c) => c.serialize_pillar(),
             _ => Ok(vec![])
         }?;
@@ -159,6 +162,9 @@ impl PillarSerialize for crate::primitives::messages::Message {
             23 => Message::Error(String::deserialize_pillar(&data[n..])?),
             24 => Message::DiscoveryRequest,
             25 => Message::DiscoveryResponse(Peer::deserialize_pillar(&data[n..])?),
+            26 => Message::EncryptedMessage(Vec::<u8>::deserialize_pillar(&data[n..])?),
+            27 => Message::PrivacyRequest(StdByteArray::deserialize_pillar(&data[n..])?),
+            28 => Message::PrivacyResponse(StdByteArray::deserialize_pillar(&data[n..])?),
             _ => return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "Unknown message code")),
         };
         Ok(result)

--- a/libs/pillar_crypto/Cargo.toml
+++ b/libs/pillar_crypto/Cargo.toml
@@ -13,3 +13,8 @@ sha3 = "0.10.8"
 slotmap = "1.0.7"
 rand = "0.9.1"
 lz4_flex = "0.11.5"
+
+x25519-dalek = "2"
+flume = "0.11.1"
+hkdf = "0.12.4"
+chacha20poly1305 = "0.10.1"

--- a/libs/pillar_crypto/README.md
+++ b/libs/pillar_crypto/README.md
@@ -33,3 +33,14 @@ This crate provides the core cryptographic primitives for the Pillar protocol.
   - Values serialized with `PillarSerialize` and stored as raw bytes.
   - Branching (`branch`): clones only necessary path nodes; reference counts track sharing.
   - Trimming (`trim_branch`): decrements references, removes unique nodes.
+
+## Encryption (`pillar_crypto::encryption`)
+
+- Shared secret via X25519 key exchange.
+- Symmetric encryption with XChaCha20-Poly1305.
+- `SharedSecret` struct encapsulates key exchange and encryption/decryption methods.
+- Usage:
+  - Generate ephemeral key pair.
+  - Exchange public keys.
+  - Derive shared secret.
+  - Encrypt/decrypt messages with the shared secret.

--- a/libs/pillar_crypto/src/encryption.rs
+++ b/libs/pillar_crypto/src/encryption.rs
@@ -1,0 +1,253 @@
+use chacha20poly1305::{AeadCore, ChaCha20Poly1305, Key, KeyInit, aead::Aead};
+use hkdf::Hkdf;
+use pillar_serialize::StdByteArray;
+use rand_core::OsRng;
+use x25519_dalek::{EphemeralSecret, PublicKey, SharedSecret};
+use sha3::Sha3_256;
+
+use crate::types::STANDARD_ARRAY_LENGTH;
+
+
+type X25519PublicKey = StdByteArray;
+
+pub struct KeyPair {
+    pub public_key: StdByteArray,
+    pub private_key: EphemeralSecret,
+}
+
+fn generate_public_private_keypair() -> KeyPair {
+    let private_key = EphemeralSecret::random_from_rng(&mut OsRng);
+    let public_key = PublicKey::from(&private_key);
+    KeyPair {
+        public_key: *public_key.as_bytes(),
+        private_key,
+    }
+}
+
+enum SecretState{
+    Initiator(EphemeralSecret),
+    Joined(ChaCha20Poly1305),
+    None // for uninitialized state, useful for mem replace
+}
+
+pub struct PillarSharedSecret{
+    pub public: X25519PublicKey,
+    state: SecretState,
+}
+
+impl PillarSharedSecret{
+
+    fn derive_cipher(shared_secret: SharedSecret) -> Result<ChaCha20Poly1305, std::io::Error> {
+        let raw_secret_bytes = shared_secret.as_bytes();
+        let hk = Hkdf::<Sha3_256>::new(None, raw_secret_bytes);
+        
+        let mut key_bytes = [0u8; STANDARD_ARRAY_LENGTH];
+        hk.expand(&[], &mut key_bytes)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("HKDF error: {:?}", e)))?;
+        
+        let key = Key::from_slice(&key_bytes);
+        Ok(ChaCha20Poly1305::new(key))
+    }
+
+    /// Initiates a key exchange, generating a new key pair
+    /// In this case, hydrate needs to be called later with the remote public key
+    pub fn initiate() -> Self {
+        let keypair = generate_public_private_keypair();
+        PillarSharedSecret{
+            public: keypair.public_key,
+            state: SecretState::Initiator(keypair.private_key),
+        }
+    }
+
+    /// Joins an existing key exchange given the remote public key
+    /// In this case, hydrate does not need to be called later
+    pub fn join(remote_public: X25519PublicKey) -> Result<Self, std::io::Error> {
+        let keypair = generate_public_private_keypair();
+        let remote_public_key = x25519_dalek::PublicKey::from(remote_public);
+        let shared_secret = keypair.private_key.diffie_hellman(&remote_public_key);
+        
+        let cipher = PillarSharedSecret::derive_cipher(shared_secret)?;
+
+        Ok(PillarSharedSecret{
+            public: keypair.public_key,
+            state: SecretState::Joined(cipher),
+        })
+    }
+
+    /// Given the remote public key, computes the shared secret
+    pub fn hydrate(&mut self, remote_public: X25519PublicKey) -> Result<(), std::io::Error> {
+        let remote_public_key = x25519_dalek::PublicKey::from(remote_public);
+        match std::mem::replace(&mut self.state, SecretState::None) {
+            SecretState::Initiator(private_key) => {
+                let shared_secret = private_key.diffie_hellman(&remote_public_key);
+                let cipher = PillarSharedSecret::derive_cipher(shared_secret)?;
+                self.state = SecretState::Joined(cipher);
+            },
+            _ => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other, 
+                    "Shared secret already established, or invalid state"
+                ));
+            },
+        }
+        Ok(())
+    }
+
+    pub fn encrypt(&self, plaintext: impl Into<Vec<u8>>) -> Result<Vec<u8>, std::io::Error> {
+        let cipher = match &self.state {
+            SecretState::Joined(c) => c,
+            _ => return Err(std::io::Error::new(
+                std::io::ErrorKind::Other, 
+                "Cipher not established. Run join or hydrate first."
+            )),
+        };
+
+        let nonce = ChaCha20Poly1305::generate_nonce(&mut OsRng); // 12 bytes
+        
+        let ciphertext_with_tag = cipher.encrypt(&nonce, plaintext.into().as_ref())
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+
+        let mut full_payload = Vec::new();
+        full_payload.extend_from_slice(nonce.as_slice());
+        full_payload.extend_from_slice(&ciphertext_with_tag);
+
+        Ok(full_payload)
+    }
+
+    pub fn decrypt(&self, ciphertext: impl Into<Vec<u8>>) -> Result<Vec<u8>, std::io::Error> {
+        let cipher = match &self.state {
+            SecretState::Joined(c) => c,
+            _ => return Err(std::io::Error::new(
+                std::io::ErrorKind::Other, 
+                "Cipher not established. Run join or hydrate first."
+            )),
+        };
+
+        let data = ciphertext.into();
+        if data.len() < 12 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Ciphertext too short to contain nonce",
+            ));
+        }
+
+        let (nonce_bytes, ciphertext_with_tag) = data.split_at(12);
+        let nonce = chacha20poly1305::Nonce::from_slice(nonce_bytes);
+
+        let plaintext = cipher.decrypt(nonce, ciphertext_with_tag)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string())
+        )?;
+
+        Ok(plaintext)
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_keypair_generation() {
+        let keypair = generate_public_private_keypair();
+        assert_eq!(keypair.public_key.len(), 32);
+    }
+
+    #[test]
+    fn test_shared_secret_encryption_decryption() {
+        // Simulate Alice initiating and Bob joining
+        let mut alice = PillarSharedSecret::initiate();
+        let bob = PillarSharedSecret::join(alice.public.clone()).unwrap();
+
+        // Alice hydrates his cipher with bob's public key
+        alice.hydrate(bob.public.clone()).unwrap();
+
+        assert!(matches!(alice.state, SecretState::Joined(_)));
+        assert!(matches!(bob.state, SecretState::Joined(_)));
+
+        let message = b"Hello Pillar!";
+        let ciphertext = alice.encrypt(message).unwrap();
+        println!("Ciphertext: {:?}", ciphertext);
+        let decrypted = bob.decrypt(ciphertext).unwrap();
+
+        assert_eq!(decrypted, message);
+    }
+
+    #[test]
+    fn test_encrypt_without_cipher() {
+        let secret = PillarSharedSecret::initiate();
+        let result = secret.encrypt(b"test");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_decrypt_without_cipher() {
+        let secret = PillarSharedSecret::initiate();
+        let result = secret.decrypt(b"test");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_decrypt_invalid_ciphertext() {
+        let mut secret = PillarSharedSecret::initiate();
+        let keypair = generate_public_private_keypair();
+        let remote_key = keypair.public_key;
+        secret.hydrate(remote_key).unwrap();
+
+        let bad_ciphertext = vec![0u8; 10]; // too short
+        let result = secret.decrypt(bad_ciphertext);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_hydrate_without_private_key() {
+        let mut secret = PillarSharedSecret{
+            public: [0u8; 32],
+            state: SecretState::None,
+        };
+        let result = secret.hydrate([1u8; 32]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_multiple_hydrate_calls() {
+        let mut alice = PillarSharedSecret::initiate();
+        let bob = PillarSharedSecret::join(alice.public.clone()).unwrap();
+
+        // First hydrate should work
+        assert!(alice.hydrate(bob.public.clone()).is_ok());
+
+        // Second hydrate should fail since private key is consumed
+        assert!(alice.hydrate(bob.public.clone()).is_err());
+    }
+
+    #[test]
+    fn test_long_message_encryption_decryption() {
+        let mut alice = PillarSharedSecret::initiate();
+        let bob = PillarSharedSecret::join(alice.public.clone()).unwrap();
+        alice.hydrate(bob.public.clone()).unwrap();
+
+        let long_message = vec![0u8; 10_000]; // 10 KB of zeros
+        let ciphertext = alice.encrypt(long_message.clone()).unwrap();
+        let decrypted = bob.decrypt(ciphertext).unwrap();
+
+        assert_eq!(decrypted, long_message);
+    }
+
+    #[test]
+    fn test_multiple_use_of_cipher() {
+        let mut alice = PillarSharedSecret::initiate();
+        let bob = PillarSharedSecret::join(alice.public.clone()).unwrap();
+        alice.hydrate(bob.public.clone()).unwrap();
+
+        let message1 = b"First message";
+        let ciphertext1 = alice.encrypt(message1).unwrap();
+        let decrypted1 = bob.decrypt(ciphertext1).unwrap();
+        assert_eq!(decrypted1, message1);
+
+        let message2 = b"Second message";
+        let ciphertext2 = alice.encrypt(message2).unwrap();
+        let decrypted2 = bob.decrypt(ciphertext2).unwrap();
+        assert_eq!(decrypted2, message2);
+    }
+}

--- a/libs/pillar_crypto/src/lib.rs
+++ b/libs/pillar_crypto/src/lib.rs
@@ -21,3 +21,5 @@ pub mod merkle_trie;
 pub mod proofs;
 /// Common type aliases and constants used by this crate.
 pub mod types;
+
+pub mod encryption;

--- a/libs/pillar_crypto/src/types.rs
+++ b/libs/pillar_crypto/src/types.rs
@@ -1,5 +1,9 @@
 //! Common type aliases used across cryptographic components.
+use pillar_serialize::StdByteArray as StdByteArraySerialize;
+use pillar_serialize::STANDARD_ARRAY_LENGTH as SERIALIZE_STANDARD_ARRAY_LENGTH;
+
+// Re-exporting types and constants for consistency across the codebase.
 /// Standard byte array length used for hashes and keys (32 bytes).
-pub const STANDARD_ARRAY_LENGTH: usize = 32;
+pub const STANDARD_ARRAY_LENGTH: usize = SERIALIZE_STANDARD_ARRAY_LENGTH;
 /// Fixed-size 32-byte array (commonly used for hashes and public keys).
-pub type StdByteArray = [u8; STANDARD_ARRAY_LENGTH];
+pub type StdByteArray = StdByteArraySerialize;

--- a/libs/pillar_serialize/src/lib.rs
+++ b/libs/pillar_serialize/src/lib.rs
@@ -30,7 +30,7 @@ use std::collections::HashMap;
 
 use bytemuck::{bytes_of, Pod, Zeroable};
 
-const STANDARD_ARRAY_LENGTH: usize = 32;
+pub const STANDARD_ARRAY_LENGTH: usize = 32;
 pub type StdByteArray = [u8; STANDARD_ARRAY_LENGTH];
 
 /// Convert integer fields of a type to little-endian in-place.


### PR DESCRIPTION
Peers can now open a secondary line of private
communication. This uses X25519 key exchange to
derive a shared secret.